### PR TITLE
Remove redundant version tag from bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,5 @@
 {
   "name": "jquery.caro",
-  "version": "1.0.1",
   "main": "./dist/jquery.caro.min.js",
   "dependencies": {
     "jquery": ">= 1.4.4"


### PR DESCRIPTION
Bower now uses git version tags instead (http://semver.org/).